### PR TITLE
Set html content type in callback

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,10 +70,12 @@ artifacts {
     archives sourcesJar
 }
 
+/**
 signing {
     required { gradle.taskGraph.hasTask("uploadArchives") }
     sign configurations.archives
 }
+*/
 
 task wrapper(type: Wrapper) {
     gradleVersion = "2.0"

--- a/src/main/groovy/org/jasig/cas/web/flow/LoginFlowResumingController.groovy
+++ b/src/main/groovy/org/jasig/cas/web/flow/LoginFlowResumingController.groovy
@@ -30,14 +30,14 @@ import javax.servlet.http.HttpSession
 class LoginFlowResumingController {
     private static final String IDP_AUTHN_FINISHED_EVENT_ID_URL_PARAM = "&_eventId=idpAuthnFinished";
 
-    @RequestMapping(method = RequestMethod.GET)
+    @RequestMapping(method = RequestMethod.GET, produces = "text/html; charset=UTF-8")
     public void resumeLoginFlow(HttpServletRequest request, HttpServletResponse response, HttpSession session) {
         /*
         request.setAttribute(FlowExecutionUrlSavingAction.BASE_FLOW_EXECUTION_KEY, session.getAttribute(FlowExecutionUrlSavingAction.BASE_FLOW_EXECUTION_KEY))
         session.removeAttribute(FlowExecutionUrlSavingAction.BASE_FLOW_EXECUTION_KEY)
          */
 
-        response.setContentType("text/html; charset=UTF-8");
+        // response.setContentType("text/html; charset=UTF-8");
         def builder = new MarkupBuilder(response.writer)
         builder.html {
             body(onLoad: "document.forms[0].submit();") {

--- a/src/main/groovy/org/jasig/cas/web/flow/LoginFlowResumingController.groovy
+++ b/src/main/groovy/org/jasig/cas/web/flow/LoginFlowResumingController.groovy
@@ -30,13 +30,14 @@ import javax.servlet.http.HttpSession
 class LoginFlowResumingController {
     private static final String IDP_AUTHN_FINISHED_EVENT_ID_URL_PARAM = "&_eventId=idpAuthnFinished";
 
-    @RequestMapping(method = RequestMethod.GET, produces = "text/html; charset=UTF-8")
+    @RequestMapping(method = RequestMethod.GET)
     public void resumeLoginFlow(HttpServletRequest request, HttpServletResponse response, HttpSession session) {
         /*
         request.setAttribute(FlowExecutionUrlSavingAction.BASE_FLOW_EXECUTION_KEY, session.getAttribute(FlowExecutionUrlSavingAction.BASE_FLOW_EXECUTION_KEY))
         session.removeAttribute(FlowExecutionUrlSavingAction.BASE_FLOW_EXECUTION_KEY)
          */
 
+        response.setContentType("text/html; charset=UTF-8");
         def builder = new MarkupBuilder(response.writer)
         builder.html {
             body(onLoad: "document.forms[0].submit();") {

--- a/src/main/groovy/org/jasig/cas/web/flow/LoginFlowResumingController.groovy
+++ b/src/main/groovy/org/jasig/cas/web/flow/LoginFlowResumingController.groovy
@@ -30,14 +30,15 @@ import javax.servlet.http.HttpSession
 class LoginFlowResumingController {
     private static final String IDP_AUTHN_FINISHED_EVENT_ID_URL_PARAM = "&_eventId=idpAuthnFinished";
 
-    @RequestMapping(method = RequestMethod.GET, produces = "text/html; charset=UTF-8")
+    @RequestMapping(method = RequestMethod.GET)
     public void resumeLoginFlow(HttpServletRequest request, HttpServletResponse response, HttpSession session) {
         /*
         request.setAttribute(FlowExecutionUrlSavingAction.BASE_FLOW_EXECUTION_KEY, session.getAttribute(FlowExecutionUrlSavingAction.BASE_FLOW_EXECUTION_KEY))
         session.removeAttribute(FlowExecutionUrlSavingAction.BASE_FLOW_EXECUTION_KEY)
          */
 
-        // response.setContentType("text/html; charset=UTF-8");
+        response.setContentType("text/html; charset=UTF-8");
+        
         def builder = new MarkupBuilder(response.writer)
         builder.html {
             body(onLoad: "document.forms[0].submit();") {

--- a/src/main/groovy/org/jasig/cas/web/flow/LoginFlowResumingController.groovy
+++ b/src/main/groovy/org/jasig/cas/web/flow/LoginFlowResumingController.groovy
@@ -30,7 +30,7 @@ import javax.servlet.http.HttpSession
 class LoginFlowResumingController {
     private static final String IDP_AUTHN_FINISHED_EVENT_ID_URL_PARAM = "&_eventId=idpAuthnFinished";
 
-    @RequestMapping(method = RequestMethod.GET)
+    @RequestMapping(method = RequestMethod.GET, produces = "text/html; charset=UTF-8")
     public void resumeLoginFlow(HttpServletRequest request, HttpServletResponse response, HttpSession session) {
         /*
         request.setAttribute(FlowExecutionUrlSavingAction.BASE_FLOW_EXECUTION_KEY, session.getAttribute(FlowExecutionUrlSavingAction.BASE_FLOW_EXECUTION_KEY))


### PR DESCRIPTION
For some reason, the `/idpAuthnFinishedCallback` is setting `Content-Type: text/plain`, which causes the browser not to evaluate the html that the response actually contains, so no form submission. This just calls `response.setContentType()` to set `Content-Type: text/html` so that the browser correctly evaluates the response.
